### PR TITLE
Replace deprecated ArrayConverter with DataConverter

### DIFF
--- a/src/main/java/de/rub/nds/protocol/crypto/ec/EllipticCurve25519.java
+++ b/src/main/java/de/rub/nds/protocol/crypto/ec/EllipticCurve25519.java
@@ -8,7 +8,7 @@
  */
 package de.rub.nds.protocol.crypto.ec;
 
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import java.math.BigInteger;
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -30,8 +30,8 @@ public class EllipticCurve25519 extends RFC7748Curve {
 
     public BigInteger decodeScalar(BigInteger scalar) {
         byte[] scalarA =
-                ArrayConverter.bigIntegerToByteArray(
-                        scalar, ArrayConverter.bigIntegerToByteArray(getModulus()).length, true);
+                DataConverter.bigIntegerToByteArray(
+                        scalar, DataConverter.bigIntegerToByteArray(getModulus()).length, true);
         scalarA[0] = (byte) (scalarA[0] & 248);
         scalarA[31] = (byte) (scalarA[31] & 127);
         scalarA[31] = (byte) (scalarA[31] | 64);
@@ -42,9 +42,9 @@ public class EllipticCurve25519 extends RFC7748Curve {
 
     public BigInteger decodeCoordinate(BigInteger encCoordinate) {
         byte[] coordinate =
-                ArrayConverter.bigIntegerToByteArray(
+                DataConverter.bigIntegerToByteArray(
                         encCoordinate,
-                        ArrayConverter.bigIntegerToByteArray(getModulus()).length,
+                        DataConverter.bigIntegerToByteArray(getModulus()).length,
                         true);
         coordinate[31] = (byte) (coordinate[31] & ((1 << 7) - 1));
         ArrayUtils.reverse(coordinate);
@@ -54,10 +54,8 @@ public class EllipticCurve25519 extends RFC7748Curve {
 
     public byte[] encodeCoordinate(BigInteger coordinate) {
         byte[] encX =
-                ArrayConverter.bigIntegerToByteArray(
-                        coordinate,
-                        ArrayConverter.bigIntegerToByteArray(getModulus()).length,
-                        true);
+                DataConverter.bigIntegerToByteArray(
+                        coordinate, DataConverter.bigIntegerToByteArray(getModulus()).length, true);
         ArrayUtils.reverse(encX);
         return encX;
     }

--- a/src/main/java/de/rub/nds/protocol/crypto/ec/EllipticCurve448.java
+++ b/src/main/java/de/rub/nds/protocol/crypto/ec/EllipticCurve448.java
@@ -8,7 +8,7 @@
  */
 package de.rub.nds.protocol.crypto.ec;
 
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import java.math.BigInteger;
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -33,8 +33,8 @@ public class EllipticCurve448 extends RFC7748Curve {
 
     public BigInteger decodeScalar(BigInteger scalar) {
         byte[] scalarA =
-                ArrayConverter.bigIntegerToByteArray(
-                        scalar, ArrayConverter.bigIntegerToByteArray(getModulus()).length, true);
+                DataConverter.bigIntegerToByteArray(
+                        scalar, DataConverter.bigIntegerToByteArray(getModulus()).length, true);
         scalarA[0] = (byte) (scalarA[0] & 252);
         scalarA[55] = (byte) (scalarA[55] | 128);
 
@@ -44,9 +44,9 @@ public class EllipticCurve448 extends RFC7748Curve {
 
     public BigInteger decodeCoordinate(BigInteger encCoordinate) {
         byte[] coordinate =
-                ArrayConverter.bigIntegerToByteArray(
+                DataConverter.bigIntegerToByteArray(
                         encCoordinate,
-                        ArrayConverter.bigIntegerToByteArray(getModulus()).length,
+                        DataConverter.bigIntegerToByteArray(getModulus()).length,
                         true);
         ArrayUtils.reverse(coordinate);
 
@@ -55,10 +55,8 @@ public class EllipticCurve448 extends RFC7748Curve {
 
     public byte[] encodeCoordinate(BigInteger coordinate) {
         byte[] encX =
-                ArrayConverter.bigIntegerToByteArray(
-                        coordinate,
-                        ArrayConverter.bigIntegerToByteArray(getModulus()).length,
-                        true);
+                DataConverter.bigIntegerToByteArray(
+                        coordinate, DataConverter.bigIntegerToByteArray(getModulus()).length, true);
         ArrayUtils.reverse(encX);
         return encX;
     }

--- a/src/main/java/de/rub/nds/protocol/crypto/ec/PointFormatter.java
+++ b/src/main/java/de/rub/nds/protocol/crypto/ec/PointFormatter.java
@@ -8,7 +8,7 @@
  */
 package de.rub.nds.protocol.crypto.ec;
 
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import de.rub.nds.protocol.constants.EcCurveEquationType;
 import de.rub.nds.protocol.constants.GroupParameters;
 import de.rub.nds.protocol.constants.NamedEllipticCurveParameters;
@@ -32,7 +32,7 @@ public class PointFormatter {
             return new byte[1];
         }
         int elementLength =
-                ArrayConverter.bigIntegerToByteArray(point.getFieldX().getModulus()).length;
+                DataConverter.bigIntegerToByteArray(point.getFieldX().getModulus()).length;
         if (groupParameters instanceof NamedEllipticCurveParameters
                 && ((NamedEllipticCurveParameters) groupParameters).getEquationType()
                         == EcCurveEquationType.SHORT_WEIERSTRASS) {
@@ -40,10 +40,10 @@ public class PointFormatter {
                 case UNCOMPRESSED:
                     stream.write(0x04);
                     stream.write(
-                            ArrayConverter.bigIntegerToNullPaddedByteArray(
+                            DataConverter.bigIntegerToNullPaddedByteArray(
                                     point.getFieldX().getData(), elementLength));
                     stream.write(
-                            ArrayConverter.bigIntegerToNullPaddedByteArray(
+                            DataConverter.bigIntegerToNullPaddedByteArray(
                                     point.getFieldY().getData(), elementLength));
                     return stream.toByteArray();
                 case COMPRESSED:
@@ -62,7 +62,7 @@ public class PointFormatter {
                         stream.write(0x02);
                     }
                     stream.write(
-                            ArrayConverter.bigIntegerToNullPaddedByteArray(
+                            DataConverter.bigIntegerToNullPaddedByteArray(
                                     point.getFieldX().getData(), elementLength));
                     return stream.toByteArray();
                 default:
@@ -70,7 +70,7 @@ public class PointFormatter {
             }
         } else {
             byte[] coordinate =
-                    ArrayConverter.bigIntegerToNullPaddedByteArray(
+                    DataConverter.bigIntegerToNullPaddedByteArray(
                             point.getFieldX().getData(), elementLength);
             stream.write(coordinate);
             return stream.toByteArray();
@@ -83,12 +83,12 @@ public class PointFormatter {
             return new byte[1];
         }
         int elementLength =
-                ArrayConverter.bigIntegerToByteArray(point.getFieldX().getModulus()).length;
+                DataConverter.bigIntegerToByteArray(point.getFieldX().getModulus()).length;
         stream.write(
-                ArrayConverter.bigIntegerToNullPaddedByteArray(
+                DataConverter.bigIntegerToNullPaddedByteArray(
                         point.getFieldX().getData(), elementLength));
         stream.write(
-                ArrayConverter.bigIntegerToNullPaddedByteArray(
+                DataConverter.bigIntegerToNullPaddedByteArray(
                         point.getFieldY().getData(), elementLength));
         return stream.toByteArray();
     }

--- a/src/main/java/de/rub/nds/protocol/crypto/ec/RFC7748Curve.java
+++ b/src/main/java/de/rub/nds/protocol/crypto/ec/RFC7748Curve.java
@@ -8,7 +8,7 @@
  */
 package de.rub.nds.protocol.crypto.ec;
 
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import java.math.BigInteger;
 import java.util.Arrays;
 import org.apache.logging.log4j.LogManager;
@@ -69,10 +69,10 @@ public abstract class RFC7748Curve extends SimulatedMontgomeryCurve {
 
     public BigInteger reduceLongKey(BigInteger key) {
         byte[] keyBytes = key.toByteArray();
-        if (keyBytes.length > ArrayConverter.bigIntegerToByteArray(getModulus()).length) {
+        if (keyBytes.length > DataConverter.bigIntegerToByteArray(getModulus()).length) {
             keyBytes =
                     Arrays.copyOfRange(
-                            keyBytes, 0, ArrayConverter.bigIntegerToByteArray(getModulus()).length);
+                            keyBytes, 0, DataConverter.bigIntegerToByteArray(getModulus()).length);
             return new BigInteger(1, keyBytes);
         } else {
             return key;

--- a/src/main/java/de/rub/nds/protocol/crypto/signature/SignatureCalculator.java
+++ b/src/main/java/de/rub/nds/protocol/crypto/signature/SignatureCalculator.java
@@ -8,7 +8,7 @@
  */
 package de.rub.nds.protocol.crypto.signature;
 
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import de.rub.nds.protocol.constants.HashAlgorithm;
 import de.rub.nds.protocol.constants.SignatureAlgorithm;
 import de.rub.nds.protocol.crypto.ec.EllipticCurve;
@@ -146,7 +146,7 @@ public class SignatureCalculator {
 
         // M' = (0x)00 00 00 00 00 00 00 00 || mHash || salt
         byte[] paddedSaltedDigest =
-                ArrayConverter.concatenate(new byte[8], digest, computations.getSalt().getValue());
+                DataConverter.concatenate(new byte[8], digest, computations.getSalt().getValue());
         computations.setPaddedSaltedDigest(paddedSaltedDigest);
         paddedSaltedDigest = computations.getPaddedSaltedDigest().getValue();
         LOGGER.debug("Padded salted digest: {}", paddedSaltedDigest);
@@ -171,7 +171,7 @@ public class SignatureCalculator {
         LOGGER.debug("Ps value: {}", psValue);
         // Generate the DB = PS || 0x01 || salt
         byte[] db =
-                ArrayConverter.concatenate(
+                DataConverter.concatenate(
                         psValue, new byte[] {0x01}, computations.getSalt().getValue());
         computations.setDbValue(db);
         db = computations.getDbValue().getValue();
@@ -191,7 +191,7 @@ public class SignatureCalculator {
         }
         // Construct the encoded message EM = maskedDB || H || 0xBC
         byte[] em =
-                ArrayConverter.concatenate(maskedDB, hValue, computations.getTfValue().getValue());
+                DataConverter.concatenate(maskedDB, hValue, computations.getTfValue().getValue());
         computations.setEmValue(em);
         em = computations.getEmValue().getValue();
         LOGGER.debug("EM: {}", em);
@@ -203,7 +203,7 @@ public class SignatureCalculator {
                 emInteger.modPow(
                         computations.getPrivateKey().getValue(),
                         computations.getModulus().getValue());
-        computations.setSignatureBytes(ArrayConverter.bigIntegerToByteArray(signature));
+        computations.setSignatureBytes(DataConverter.bigIntegerToByteArray(signature));
         computations.setSignatureValid(true);
     }
 
@@ -227,22 +227,22 @@ public class SignatureCalculator {
         int counter = 0;
 
         while (counter < (length / mgfhLen)) {
-            counterBytes = ArrayConverter.intToBytes(counter, 4);
+            counterBytes = DataConverter.intToBytes(counter, 4);
 
             hashBuf =
                     HashCalculator.compute(
-                            ArrayConverter.concatenate(input, counterBytes), mgfAlgorithm);
+                            DataConverter.concatenate(input, counterBytes), mgfAlgorithm);
             System.arraycopy(hashBuf, 0, mask, counter * mgfhLen, mgfhLen);
 
             counter++;
         }
 
         if ((counter * mgfhLen) < length) {
-            counterBytes = ArrayConverter.intToBytes(counter, 4);
+            counterBytes = DataConverter.intToBytes(counter, 4);
 
             hashBuf =
                     HashCalculator.compute(
-                            ArrayConverter.concatenate(input, counterBytes), mgfAlgorithm);
+                            DataConverter.concatenate(input, counterBytes), mgfAlgorithm);
 
             System.arraycopy(
                     hashBuf, 0, mask, counter * mgfhLen, mask.length - (counter * mgfhLen));
@@ -275,11 +275,11 @@ public class SignatureCalculator {
             derEncoded = computations.getDerEncodedDigest().getValue();
         }
         int modLength =
-                ArrayConverter.bigIntegerToByteArray(computations.getModulus().getValue()).length;
+                DataConverter.bigIntegerToByteArray(computations.getModulus().getValue()).length;
         byte[] padding = computePkcs1Padding(derEncoded.length, modLength);
         computations.setPadding(padding);
         padding = computations.getPadding().getValue();
-        byte[] plainData = ArrayConverter.concatenate(padding, derEncoded);
+        byte[] plainData = DataConverter.concatenate(padding, derEncoded);
         computations.setPlainToBeSigned(plainData);
         plainData = computations.getPlainToBeSigned().getValue();
         BigInteger plainInteger = new BigInteger(plainData);
@@ -288,7 +288,7 @@ public class SignatureCalculator {
                         computations.getPrivateKey().getValue(),
                         computations.getModulus().getValue());
         computations.setSignatureBytes(
-                ArrayConverter.bigIntegerToByteArray(signature, modLength, true));
+                DataConverter.bigIntegerToByteArray(signature, modLength, true));
         computations.setSignatureValid(true);
     }
 
@@ -336,7 +336,7 @@ public class SignatureCalculator {
         computations.setPrivateKey(privateKey.getX());
 
         LOGGER.trace("Computing DSA signature");
-        int groupSize = ArrayConverter.bigIntegerToByteArray(privateKey.getQ()).length;
+        int groupSize = DataConverter.bigIntegerToByteArray(privateKey.getQ()).length;
         // not persisted in computation as they can be set before the calculation
         LOGGER.debug("g: " + computations.getG().getValue());
         LOGGER.debug("p: " + computations.getP().getValue());
@@ -349,13 +349,12 @@ public class SignatureCalculator {
         digest = computations.getDigestBytes().getValue();
         LOGGER.debug(
                 "toBeSignedBytes: "
-                        + ArrayConverter.bytesToHexString(
+                        + DataConverter.bytesToHexString(
                                 computations.getToBeSignedBytes().getValue()));
 
         LOGGER.debug(
                 "Digest: "
-                        + ArrayConverter.bytesToHexString(
-                                computations.getDigestBytes().getValue()));
+                        + DataConverter.bytesToHexString(computations.getDigestBytes().getValue()));
 
         // z = e[0:l], with l bit length of group order
         byte[] truncatedHashBytes =
@@ -399,8 +398,8 @@ public class SignatureCalculator {
         computations.setS(s);
         s = computations.getS().getValue();
 
-        LOGGER.debug("s: " + ArrayConverter.bytesToHexString(s.toByteArray()));
-        LOGGER.debug("r: " + ArrayConverter.bytesToHexString(r.toByteArray()));
+        LOGGER.debug("s: " + DataConverter.bytesToHexString(s.toByteArray()));
+        LOGGER.debug("r: " + DataConverter.bytesToHexString(r.toByteArray()));
 
         ASN1Integer asn1IntegerR = new ASN1Integer(r);
         ASN1Integer asn1IntegerS = new ASN1Integer(s);
@@ -443,7 +442,7 @@ public class SignatureCalculator {
                 HashCalculator.compute(computations.getToBeSignedBytes().getValue(), hashAlgorithm);
         computations.setDigestBytes(hash);
         hash = computations.getDigestBytes().getValue();
-        LOGGER.debug("Digest: " + ArrayConverter.bytesToHexString(hash));
+        LOGGER.debug("Digest: " + DataConverter.bytesToHexString(hash));
 
         // z = e[0:l], with l bit length of group order
         byte[] truncatedHashBytes = Arrays.copyOfRange(hash, 0, Math.min(groupSize, hash.length));
@@ -451,7 +450,7 @@ public class SignatureCalculator {
 
         LOGGER.debug(
                 "TruncatedHashBytes: "
-                        + ArrayConverter.bytesToHexString(
+                        + DataConverter.bytesToHexString(
                                 computations.getTruncatedHashBytes().getValue()));
         computations.setTruncatedHash(
                 new BigInteger(1, (computations.getTruncatedHashBytes().getValue())));
@@ -494,8 +493,8 @@ public class SignatureCalculator {
 
         SilentByteArrayOutputStream outputStream = new SilentByteArrayOutputStream();
 
-        outputStream.write(ArrayConverter.bigIntegerToByteArray(r, 32, true));
-        outputStream.write(ArrayConverter.bigIntegerToByteArray(s, 32, true));
+        outputStream.write(DataConverter.bigIntegerToByteArray(r, 32, true));
+        outputStream.write(DataConverter.bigIntegerToByteArray(s, 32, true));
 
         byte[] completeSignature = outputStream.toByteArray();
         computations.setSignatureBytes(completeSignature);
@@ -527,7 +526,7 @@ public class SignatureCalculator {
                 HashCalculator.compute(computations.getToBeSignedBytes().getValue(), hashAlgorithm);
         computations.setDigestBytes(hash);
         hash = computations.getDigestBytes().getValue();
-        LOGGER.debug("Digest: " + ArrayConverter.bytesToHexString(hash));
+        LOGGER.debug("Digest: " + DataConverter.bytesToHexString(hash));
 
         // z = e[0:l], with l bit length of group order
         byte[] truncatedHashBytes = Arrays.copyOfRange(hash, 0, Math.min(groupSize, hash.length));
@@ -535,7 +534,7 @@ public class SignatureCalculator {
 
         LOGGER.debug(
                 "TruncatedHashBytes: "
-                        + ArrayConverter.bytesToHexString(
+                        + DataConverter.bytesToHexString(
                                 computations.getTruncatedHashBytes().getValue()));
         computations.setTruncatedHash(
                 new BigInteger(1, (computations.getTruncatedHashBytes().getValue())));

--- a/src/test/java/de/rub/nds/protocol/crypto/ec/PointFormatterTest.java
+++ b/src/test/java/de/rub/nds/protocol/crypto/ec/PointFormatterTest.java
@@ -10,7 +10,7 @@ package de.rub.nds.protocol.crypto.ec;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import de.rub.nds.protocol.constants.EcCurveEquationType;
 import de.rub.nds.protocol.constants.NamedEllipticCurveParameters;
 import de.rub.nds.protocol.constants.PointFormat;
@@ -105,7 +105,7 @@ public class PointFormatterTest {
     public void testCompressionFormat(
             NamedEllipticCurveParameters namedCurveParameters, String expectedCompressedBasePoint) {
         byte[] expectedCompressedBasePointBytes =
-                ArrayConverter.hexStringToByteArray(expectedCompressedBasePoint);
+                DataConverter.hexStringToByteArray(expectedCompressedBasePoint);
         EllipticCurve curve = namedCurveParameters.getGroup();
         byte[] actualCompressedBasePointBytes =
                 PointFormatter.formatToByteArray(

--- a/src/test/java/de/rub/nds/protocol/crypto/signature/SignatureCalculatorTest.java
+++ b/src/test/java/de/rub/nds/protocol/crypto/signature/SignatureCalculatorTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import de.rub.nds.modifiablevariable.util.ArrayConverter;
+import de.rub.nds.modifiablevariable.util.DataConverter;
 import de.rub.nds.modifiablevariable.util.Modifiable;
 import de.rub.nds.protocol.constants.HashAlgorithm;
 import de.rub.nds.protocol.constants.NamedEllipticCurveParameters;
@@ -54,12 +54,12 @@ public class SignatureCalculatorTest {
         BigInteger modulus =
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "00cbfb45e6b09f1af40df60ddc865b6f98a1fd724678b583bfb5ae8539627bffdcd930d7c3f996f75e15172a017f143101ecd28fc629b800e24f0a83665d77c0a3"));
         BigInteger privateKey =
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "61a4eb153f3f2a9be18303a7a8f964366074fe9b15756e97fad48c19a8374b870589dde72e4377f3837ab59fa76b55563642f2df635da71a3aa50ab835201b61"));
         byte[] toBeSignedBytes = "abcdefghijklmnopqrstuvwxyz\n".getBytes();
         HashAlgorithm hashAlgorithm = HashAlgorithm.SHA1;
@@ -72,24 +72,24 @@ public class SignatureCalculatorTest {
         assertArrayEquals(toBeSignedBytes, computations.getToBeSignedBytes().getValue());
 
         assertArrayEquals(
-                ArrayConverter.hexStringToByteArray("8c723a0fa70b111017b4a6f06afe1c0dbcec14e3"),
+                DataConverter.hexStringToByteArray("8c723a0fa70b111017b4a6f06afe1c0dbcec14e3"),
                 computations.getDigestBytes().getValue());
         assertArrayEquals(
-                ArrayConverter.hexStringToByteArray(
+                DataConverter.hexStringToByteArray(
                         "3021300906052b0e03021a050004148c723a0fa70b111017b4a6f06afe1c0dbcec14e3"),
                 computations.getDerEncodedDigest().getValue());
 
         assertEquals(HashAlgorithm.SHA1, computations.getHashAlgorithm());
         assertArrayEquals(
-                ArrayConverter.hexStringToByteArray(
+                DataConverter.hexStringToByteArray(
                         "0001ffffffffffffffffffffffffffffffffffffffffffffffffffff00"),
                 computations.getPadding().getValue());
         assertArrayEquals(
-                ArrayConverter.hexStringToByteArray(
+                DataConverter.hexStringToByteArray(
                         "0001ffffffffffffffffffffffffffffffffffffffffffffffffffff003021300906052b0e03021a050004148c723a0fa70b111017b4a6f06afe1c0dbcec14e3"),
                 computations.getPlainToBeSigned().getValue());
         assertArrayEquals(
-                ArrayConverter.hexStringToByteArray(
+                DataConverter.hexStringToByteArray(
                         "9139be98f16cf53d22da63cb559bb06a93338da6a344e28a4285c2da33facb7080d26e7a09483779a016eebc207602fc3f90492c2f2fb8143f0fe30fd855593d"),
                 computations.getSignatureBytes().getValue());
         assertArrayEquals(toBeSignedBytes, computations.getToBeSignedBytes().getValue());
@@ -111,28 +111,28 @@ public class SignatureCalculatorTest {
         BigInteger privateKey =
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "D0EC4E50BB290A42E9E355C73D8809345DE2E139"));
-        byte[] toBeSignedBytes = ArrayConverter.hexStringToByteArray("616263");
+        byte[] toBeSignedBytes = DataConverter.hexStringToByteArray("616263");
         BigInteger nonce =
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "349C55648DCF992F3F33E8026CFAC87C1D2BA075"));
         BigInteger q =
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "E950511EAB424B9A19A2AEB4E159B7844C589C4F"));
         BigInteger g =
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "D29D5121B0423C2769AB21843E5A3240FF19CACC792264E3BB6BE4F78EDD1B15C4DFF7F1D905431F0AB16790E1F773B5CE01C804E509066A9919F5195F4ABC58189FD9FF987389CB5BEDF21B4DAB4F8B76A055FFE2770988FE2EC2DE11AD92219F0B351869AC24DA3D7BA87011A701CE8EE7BFE49486ED4527B7186CA4610A75"));
         BigInteger p =
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "E0A67598CD1B763BC98C8ABB333E5DDA0CD3AA0E5E1FB5BA8A7B4EABC10BA338FAE06DD4B90FDA70D7CF0CB0C638BE3341BEC0AF8A7330A3307DED2299A0EE606DF035177A239C34A912C202AA5F83B9C4A7CF0235B5316BFC6EFB9A248411258B30B839AF172440F32563056CB67A861158DDD90E6A894C72A5BBEF9E286C6B"));
         HashAlgorithm hashAlgorithm = HashAlgorithm.SHA1;
         SignatureCalculator instance = new SignatureCalculator();
@@ -157,66 +157,66 @@ public class SignatureCalculatorTest {
         assertEquals(
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "D29D5121B0423C2769AB21843E5A3240FF19CACC792264E3BB6BE4F78EDD1B15C4DFF7F1D905431F0AB16790E1F773B5CE01C804E509066A9919F5195F4ABC58189FD9FF987389CB5BEDF21B4DAB4F8B76A055FFE2770988FE2EC2DE11AD92219F0B351869AC24DA3D7BA87011A701CE8EE7BFE49486ED4527B7186CA4610A75")),
                 computations.getG().getValue());
         assertEquals(
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "D557A1B4E7346C4A55427A28D47191381C269BDE")),
                 computations.getInverseNonce().getValue());
         assertEquals(
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "349C55648DCF992F3F33E8026CFAC87C1D2BA075")),
                 computations.getNonce().getValue());
         assertEquals(
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "E0A67598CD1B763BC98C8ABB333E5DDA0CD3AA0E5E1FB5BA8A7B4EABC10BA338FAE06DD4B90FDA70D7CF0CB0C638BE3341BEC0AF8A7330A3307DED2299A0EE606DF035177A239C34A912C202AA5F83B9C4A7CF0235B5316BFC6EFB9A248411258B30B839AF172440F32563056CB67A861158DDD90E6A894C72A5BBEF9E286C6B")),
                 computations.getP().getValue());
         assertEquals(
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "D0EC4E50BB290A42E9E355C73D8809345DE2E139")),
                 computations.getPrivateKey().getValue());
         assertEquals(
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "E950511EAB424B9A19A2AEB4E159B7844C589C4F")),
                 computations.getQ().getValue());
         assertEquals(
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "636155AC9A4633B4665D179F9E4117DF68601F34")),
                 computations.getR().getValue());
         assertEquals(
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "6C540B02D9D4852F89DF8CFC99963204F4347704")),
                 computations.getS().getValue());
         assertTrue(computations.getSignatureValid());
         assertArrayEquals(
-                ArrayConverter.hexStringToByteArray(
+                DataConverter.hexStringToByteArray(
                         "302C0214636155AC9A4633B4665D179F9E4117DF68601F3402146C540B02D9D4852F89DF8CFC99963204F4347704"),
                 computations.getSignatureBytes().getValue());
         assertArrayEquals(
-                ArrayConverter.hexStringToByteArray("616263"),
+                DataConverter.hexStringToByteArray("616263"),
                 computations.getToBeSignedBytes().getValue());
         assertArrayEquals(
-                ArrayConverter.hexStringToByteArray("A9993E364706816ABA3E25717850C26C9CD0D89D"),
+                DataConverter.hexStringToByteArray("A9993E364706816ABA3E25717850C26C9CD0D89D"),
                 computations.getTruncatedHashBytes().getValue());
         assertEquals(
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "5D69A2B1B6988FFA5FA41AFAE8526C15535D7B35")),
                 computations.getXr().getValue());
     }
@@ -229,10 +229,10 @@ public class SignatureCalculatorTest {
         BigInteger privateKey =
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "519b423d715f8b581f4fa8ee59f4771a5b44c8130b4e3eacca54a56dda72b464"));
         byte[] toBeSignedBytes =
-                ArrayConverter.hexStringToByteArray(
+                DataConverter.hexStringToByteArray(
                         "44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56");
         computations.setDigestBytes(Modifiable.explicit(toBeSignedBytes));
         computations.setTruncatedHashBytes(
@@ -242,7 +242,7 @@ public class SignatureCalculatorTest {
         BigInteger nonce =
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "94a1bbb14b906a61a280f245f9e93c7f3b4a6247824f5d33b9670787642a68de"));
         NamedEllipticCurveParameters ecParameters = NamedEllipticCurveParameters.SECP256R1;
         HashAlgorithm hashAlgorithm = HashAlgorithm.SHA256;
@@ -258,40 +258,40 @@ public class SignatureCalculatorTest {
         assertEquals(
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "94a1bbb14b906a61a280f245f9e93c7f3b4a6247824f5d33b9670787642a68de")),
                 computations.getNonce().getValue());
         assertEquals(
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "519b423d715f8b581f4fa8ee59f4771a5b44c8130b4e3eacca54a56dda72b464")),
                 computations.getPrivateKey().getValue());
 
         assertArrayEquals(
-                ArrayConverter.hexStringToByteArray(
+                DataConverter.hexStringToByteArray(
                         "44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56"),
                 computations.getToBeSignedBytes().getValue());
         assertEquals(
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56")),
                 computations.getTruncatedHash().getValue());
         assertArrayEquals(
-                ArrayConverter.hexStringToByteArray(
+                DataConverter.hexStringToByteArray(
                         "44acf6b7e36c1342c2c5897204fe09504e1e2efb1a900377dbc4e7a6a133ec56"),
                 computations.getTruncatedHashBytes().getValue());
         assertEquals(
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "f3ac8061b514795b8843e3d6629527ed2afd6b1f6a555a7acabb5e6f79c8c2ac")),
                 computations.getR().getValue());
         assertEquals(
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "8bf77819ca05a6b2786c76262bf7371cef97b218e96f175a3ccdda2acc058903")),
                 computations.getS().getValue());
         assertTrue(computations.getSignatureValid());
@@ -305,12 +305,12 @@ public class SignatureCalculatorTest {
         BigInteger modulus =
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "00cbfb45e6b09f1af40df60ddc865b6f98a1fd724678b583bfb5ae8539627bffdcd930d7c3f996f75e15172a017f143101ecd28fc629b800e24f0a83665d77c0a3"));
         BigInteger privateKey =
                 new BigInteger(
                         1,
-                        ArrayConverter.hexStringToByteArray(
+                        DataConverter.hexStringToByteArray(
                                 "61a4eb153f3f2a9be18303a7a8f964366074fe9b15756e97fad48c19a8374b870589dde72e4377f3837ab59fa76b55563642f2df635da71a3aa50ab835201b61"));
         BigInteger publicExponent = new BigInteger("65537");
         RsaPrivateKey rsaPrivateKey = new RsaPrivateKey(privateKey, modulus);
@@ -325,7 +325,7 @@ public class SignatureCalculatorTest {
 
         LOGGER.debug(
                 "Signature: {}",
-                ArrayConverter.bytesToHexString(computations.getSignatureBytes().getValue())
+                DataConverter.bytesToHexString(computations.getSignatureBytes().getValue())
                         .toUpperCase());
 
         Signature signature = Signature.getInstance("SHA256withRSA/PSS");


### PR DESCRIPTION
## Summary
- Replaced all occurrences of ArrayConverter with DataConverter throughout the Protocol-Attacker codebase
- Updated imports from `de.rub.nds.modifiablevariable.util.ArrayConverter` to `de.rub.nds.modifiablevariable.util.DataConverter`
- Updated all method calls to use DataConverter instead of ArrayConverter

## Changes
This PR updates 7 files in the crypto module:
- `src/main/java/de/rub/nds/protocol/crypto/ec/EllipticCurve25519.java`
- `src/main/java/de/rub/nds/protocol/crypto/ec/EllipticCurve448.java`
- `src/main/java/de/rub/nds/protocol/crypto/ec/PointFormatter.java`
- `src/main/java/de/rub/nds/protocol/crypto/ec/RFC7748Curve.java`
- `src/main/java/de/rub/nds/protocol/crypto/signature/SignatureCalculator.java`
- `src/test/java/de/rub/nds/protocol/crypto/ec/PointFormatterTest.java`
- `src/test/java/de/rub/nds/protocol/crypto/signature/SignatureCalculatorTest.java`

## Test plan
- [ ] Build the project with `mvn clean package`
- [ ] Run all tests with `mvn test`
- [ ] Verify that all ArrayConverter references have been replaced

🤖 Generated with [Claude Code](https://claude.ai/code)